### PR TITLE
wallet: Fix bug when just created encrypted wallet cannot get address

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -58,6 +58,7 @@ bool AddWallet(const std::shared_ptr<CWallet>& wallet)
     if (i != vpwallets.end()) return false;
     vpwallets.push_back(wallet);
     wallet->ConnectScriptPubKeyManNotifiers();
+    wallet->NotifyCanGetAddressesChanged();
     return true;
 }
 


### PR DESCRIPTION
This is a fix to the QT wallet bug where is you create a new encrypted wallet you cannot generate a new receiving address, as mentioned in this Bitcoin Core issue: https://github.com/bitcoin-core/gui/issues/105