### PR TITLE
Cache powhashes in a persistent database

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -434,6 +434,8 @@ libbitcoin_consensus_a_SOURCES = \
   consensus/params.h \
   consensus/tx_check.cpp \
   consensus/validation.h \
+  dbwrapper.cpp \
+  dbwrapper.h \
   hash.cpp \
   hash.h \
   prevector.h \
@@ -441,6 +443,8 @@ libbitcoin_consensus_a_SOURCES = \
   primitives/block.h \
   primitives/transaction.cpp \
   primitives/transaction.h \
+  powcache.cpp \
+  powcache.h \
   pubkey.cpp \
   pubkey.h \
   script/bitcoinconsensus.cpp \
@@ -610,11 +614,17 @@ bitcoin_tx_SOURCES += bitcoin-tx-res.rc
 endif
 
 bitcoin_tx_LDADD = \
-  $(LIBUNIVALUE) \
+  $(LIBBITCOIN_SERVER) \
+  $(LIBBITCOIN_WALLET) \
   $(LIBBITCOIN_COMMON) \
+  $(LIBUNIVALUE) \
   $(LIBBITCOIN_UTIL) \
+  $(LIBBITCOIN_ZMQ) \
   $(LIBBITCOIN_CONSENSUS) \
   $(LIBBITCOIN_CRYPTO) \
+  $(LIBLEVELDB) \
+  $(LIBLEVELDB_SSE42) \
+  $(LIBMEMENV) \
   $(LIBSECP256K1)
 
 bitcoin_tx_LDADD += $(BOOST_LIBS)
@@ -658,7 +668,7 @@ endif
 
 libbitcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
 libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1)
-libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL $(BOOST_CPPFLAGS)
+libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL $(BOOST_CPPFLAGS)
 libbitcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 
 endif

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -163,6 +163,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::QT, "qt"},
     {BCLog::LEVELDB, "leveldb"},
     {BCLog::VALIDATION, "validation"},
+    {BCLog::POWCACHE, "powcache"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -55,6 +55,7 @@ namespace BCLog {
         QT          = (1 << 19),
         LEVELDB     = (1 << 20),
         VALIDATION  = (1 << 21),
+        POWCACHE    = (1 << 22),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/powcache.cpp
+++ b/src/powcache.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 barrystyle
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <powcache.h>
+
+PowCacheDB pow_cache(GetDataDir(false) / "powcache", 4194304, false, false);
+
+PowCacheDB::PowCacheDB(fs::path ldb_path, size_t nCacheSize, bool fMemory, bool fWipe) :
+    db(ldb_path, nCacheSize, fMemory, fWipe, true)
+{}
+
+bool PowCacheDB::HaveCacheEntry(const uint256& lookupHash) const {
+    return db.Exists(lookupHash);
+}
+
+bool PowCacheDB::GetCacheEntry(const uint256& lookupHash, uint256& powHash) const {
+    return db.Read(lookupHash, powHash);
+}
+
+bool PowCacheDB::WriteCacheEntry(const uint256& lookupHash, uint256& powHash) {
+    return db.Write(lookupHash, powHash);
+}
+

--- a/src/powcache.h
+++ b/src/powcache.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 barrystyle
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POWCACHE_H
+#define BITCOIN_POWCACHE_H
+
+#include <dbwrapper.h>
+#include <uint256.h>
+
+/** Implements a persistent hash lookup cache, using SHA1 hash as the key
+ * allowing instant retrieval of the more cpu-expensive pow hash if known.
+ * The hash is not tied to a height, preventing invalid hashes from potentially
+ * being returned in the instance of a block reorganisation etc.
+ */
+class PowCacheDB
+{
+protected:
+    CDBWrapper db;
+
+private:
+    int hit_log{0};
+    int miss_log{0};
+
+public:
+    explicit PowCacheDB(fs::path ldb_path, size_t nCacheSize, bool fMemory, bool fWipe);
+
+    int hit(bool inc = false) {
+        if (inc) ++hit_log;
+        return hit_log;
+    }
+    int miss(bool inc = false) {
+        if (inc) ++miss_log;
+        return miss_log;
+    }
+
+    bool HaveCacheEntry(const uint256& lookupHash) const;
+    bool GetCacheEntry(const uint256& lookupHash, uint256& powHash) const;
+    bool WriteCacheEntry(const uint256& lookupHash, uint256& powHash);
+};
+
+extern PowCacheDB pow_cache;
+
+#endif // BITCOIN_POWCACHE_H

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -1,9 +1,13 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2022 barrystyle
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <crypto/sha1.h>
+#include <logging.h>
 #include <primitives/block.h>
+#include <powcache.h>
 #include <hash.h>
 #include <tinyformat.h>
 
@@ -12,7 +16,33 @@ uint256 CBlockHeader::GetHash() const
     return GetPoWHash();
 }
 
+uint256 CBlockHeader::GetLightHash() const
+{
+    uint256 hash;
+    CSHA1().Write((const unsigned char*)this, 80).Finalize((unsigned char*)&hash);
+    return hash;
+}
+
 uint256 CBlockHeader::GetPoWHash() const
+{
+    //! light sha1 hash for lookup
+    const uint256 lookupHash = GetLightHash();
+    bool cacheEntry = pow_cache.HaveCacheEntry(lookupHash);
+    if (cacheEntry) {
+        uint256 powHash;
+        pow_cache.GetCacheEntry(lookupHash, powHash);
+        LogPrint(BCLog::POWCACHE, "%s - cachehit %6d cachemiss %6d (%s)\n", __func__, pow_cache.hit(true), pow_cache.miss(), powHash.ToString());
+        return powHash;
+    }
+
+    //! store for later usage
+    uint256 powHash = GetHeavyHash();
+    pow_cache.WriteCacheEntry(lookupHash, powHash);
+    LogPrint(BCLog::POWCACHE, "%s - cachehit %6d cachemiss %6d (%s)\n", __func__, pow_cache.hit(), pow_cache.miss(true), powHash.ToString());
+    return powHash;
+}
+
+uint256 CBlockHeader::GetHeavyHash() const
 {
     uint256 seed;
     CSHA3_256().Write(hashPrevBlock.begin(), 32).Finalize(seed.begin());

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -62,6 +62,8 @@ public:
 
     uint256 GetHash() const;
     uint256 GetPoWHash() const;
+    uint256 GetLightHash() const;
+    uint256 GetHeavyHash() const;
 
     int64_t GetBlockTime() const
     {


### PR DESCRIPTION
This PR implements a persistent database which stores previously calculated PoW hashes.
After the block index has been passed through once, client startup is instant and lag present during syncing operations is no longer existent.