### PR TITLE
BUG FIX: add namespace std to abs func

### DIFF
--- a/src/matrix-utils/singular/Svd.h
+++ b/src/matrix-utils/singular/Svd.h
@@ -47,7 +47,7 @@ namespace singular {
         static inline bool isFullRank(const DiagonalMatrix< M, N >& singularValues, const int size) {
             const double round_off = 1.000009e-12;
             for (int i = 0; i < size; ++i) {
-                if (abs( singularValues(i, i) ) < round_off)
+                if (std::abs( singularValues(i, i) ) < round_off)
                     return false;
             }
             return true;


### PR DESCRIPTION
In docker, using the next dockerfile:
```
FROM debian:stretch-slim as bitcoind-builder

# RUN mkdir -p /app \
#   && chown -R nobody:nogroup /app
# WORKDIR /app

# # Source: https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#ubuntu--debian
RUN apt-get update && apt-get install -y make gcc g++ autoconf autotools-dev bsdmainutils build-essential git libboost-all-dev \
  libcurl4-openssl-dev libdb++-dev libevent-dev libssl-dev libtool pkg-config python python-pip libzmq3-dev wget pkg-config tar dirmngr curl

# # VERSION: Bitcoin Core 0.20.1
RUN git clone https://github.com/PoWx-Org/obtc-core.git \
  && mv obtc-core bitcoin \
  && cd bitcoin \
  && git checkout 375451f610f717bd7b192e2f2c678fe3d8f4290c

RUN cd bitcoin/depends \
  && make -j16 HOST=x86_64-pc-linux-gnu 
  
RUN cd /bitcoin \
  && ls \
  && ./autogen.sh \
  && CONFIG_SITE=$PWD/depends/x86_64-pc-linux-gnu/share/config.site ./configure --prefix=/ 

RUN cd /bitcoin \
  && make -j16

```
The compilation process fails because of the ambiguous abs function:
```
In file included from util/matrixchecks.cpp:5:0:
./matrix-utils/singular/Svd.h: In instantiation of 'static bool singular::Svd<M, N>::isFullRank(const singular::DiagonalMatrix<M, N>&, int) [with int M = 64; int N = 64]':
util/matrixchecks.cpp:28:37:   required from here
./matrix-utils/singular/Svd.h:50:24: error: call of overloaded 'abs(double)' is ambiguous
                 if (abs( singularValues(i, i) ) < round_off)
                     ~~~^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/6/cstdlib:75:0,
                 from /usr/include/c++/6/stdlib.h:36,
                 from util/matrixchecks.cpp:2:
/usr/include/stdlib.h:735:12: note: candidate: int abs(int)
 extern int abs (int __x) __THROW __attribute__ ((__const__)) __wur;
            ^~~
In file included from /usr/include/c++/6/stdlib.h:36:0,
                 from util/matrixchecks.cpp:2:
/usr/include/c++/6/cstdlib:180:3: note: candidate: long long int std::abs(long long int)
   abs(long long __x) { return __builtin_llabs (__x); }
   ^~~
/usr/include/c++/6/cstdlib:172:3: note: candidate: long int std::abs(long int)
   abs(long __i) { return __builtin_labs(__i); }
   ^~~
Makefile:11070: recipe for target 'util/libbitcoin_util_a-matrixchecks.o' failed
make[2]: *** [util/libbitcoin_util_a-matrixchecks.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/bitcoin/src'
Makefile:16813: recipe for target 'all-recursive' failed
make[1]: Leaving directory '/bitcoin/src'
make[1]: *** [all-recursive] Error 1
Makefile:781: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1
```
This is fixed by adding namespace std to `Svd.h` file.
Note that this file is added by the obtc project, and the error does not appear without static linking; Even with static linking it does not appear on other distros(tested on ubuntu 20.04). That is why it was not spotted before.

Static linking is needed to create a lightweight bitcoin executable.
