### PR TITLE
Removes libbitcoinconsensus build by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -491,9 +491,9 @@ AC_ARG_ENABLE([util-wallet],
 
 AC_ARG_WITH([libs],
   [AS_HELP_STRING([--with-libs],
-  [build libraries (default=yes)])],
+  [build libraries (default=no)])],
   [build_bitcoin_libs=$withval],
-  [build_bitcoin_libs=yes])
+  [build_bitcoin_libs=no])
 
 AC_ARG_WITH([daemon],
   [AS_HELP_STRING([--with-daemon],


### PR DESCRIPTION
`libbitcoinconsensus` is a shared library that is used as a standard, when benchmarking 3d party consensus-critical applications.
My suggestion is to disable the build of `libbitcoinconsensus` by default, this will result in cleaner and faster builds. 
Those in need of the library file may simply run:
`./configure --with-libs=yes`

_For a nightly branch_