### PR TITLE
Heavy Hash cache

### DIFF
--- a/doc/files.md
+++ b/doc/files.md
@@ -45,6 +45,7 @@ Subdirectory       | File(s)               | Description
 `blocks/`          | `blkNNNNN.dat`<sup>[\[2\]](#note2)</sup> | Actual Bitcoin blocks (in network format, dumped in raw on disk, 128 MiB per file)
 `blocks/`          | `revNNNNN.dat`<sup>[\[2\]](#note2)</sup> | Block undo data (custom format)
 `chainstate/`      | LevelDB database      | Blockchain state (a compact representation of all currently unspent transaction outputs and some metadata about the transactions they are from)
+`powcache/`        | LevelDB database      | Heavy hash store. Keeps heavy hashes on disk, and uses a light SHA1 as a key for a lookup
 `indexes/txindex/` | LevelDB database      | Transaction index; *optional*, used if `-txindex=1`
 `indexes/blockfilter/basic/db/` | LevelDB database      | Blockfilter index LevelDB database for the basic filtertype; *optional*, used if `-blockfilterindex=basic`
 `indexes/blockfilter/basic/`    | `fltrNNNNN.dat`<sup>[\[2\]](#note2)</sup> | Blockfilter index filters for the basic filtertype; *optional*, used if `-blockfilterindex=basic`

--- a/doc/release-notes/release-notes-obtc-0.3.0.md
+++ b/doc/release-notes/release-notes-obtc-0.3.0.md
@@ -1,0 +1,26 @@
+Version 0.3.0
+===============================
+
+Summary
+===============================
+
+This version contains an enhancement related to long block indexation and wallet rescaning, which requires chain marching.
+A new leveldb database is added, which is stored in `powcache` file.
+Due to the fact that computing block's heavy hash is very expensive, it is stored in the `powcache` database.
+
+Key -> Value: SHA1 -> Heavy Hash
+
+Compatibility
+===============================
+
+It is fully compatile with the previous versions, and has no forking potential.
+
+Updated and new sources
+===============================
+
+- powcache.*
+- block.*
+- logging.*
+- init.cpp
+- txdb.cpp
+- validation.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -434,6 +434,8 @@ libbitcoin_consensus_a_SOURCES = \
   consensus/params.h \
   consensus/tx_check.cpp \
   consensus/validation.h \
+  dbwrapper.cpp \
+  dbwrapper.h \
   hash.cpp \
   hash.h \
   prevector.h \
@@ -441,6 +443,8 @@ libbitcoin_consensus_a_SOURCES = \
   primitives/block.h \
   primitives/transaction.cpp \
   primitives/transaction.h \
+  powcache.cpp \
+  powcache.h \
   pubkey.cpp \
   pubkey.h \
   script/bitcoinconsensus.cpp \
@@ -610,11 +614,17 @@ bitcoin_tx_SOURCES += bitcoin-tx-res.rc
 endif
 
 bitcoin_tx_LDADD = \
-  $(LIBUNIVALUE) \
+  $(LIBBITCOIN_SERVER) \
+  $(LIBBITCOIN_WALLET) \
   $(LIBBITCOIN_COMMON) \
+  $(LIBUNIVALUE) \
   $(LIBBITCOIN_UTIL) \
+  $(LIBBITCOIN_ZMQ) \
   $(LIBBITCOIN_CONSENSUS) \
   $(LIBBITCOIN_CRYPTO) \
+  $(LIBLEVELDB) \
+  $(LIBLEVELDB_SSE42) \
+  $(LIBMEMENV) \
   $(LIBSECP256K1)
 
 bitcoin_tx_LDADD += $(BOOST_LIBS)
@@ -658,7 +668,7 @@ endif
 
 libbitcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
 libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1)
-libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL $(BOOST_CPPFLAGS)
+libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL $(BOOST_CPPFLAGS)
 libbitcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -173,6 +173,7 @@ BITCOIN_CORE_H = \
   policy/rbf.h \
   policy/settings.h \
   pow.h \
+  powcache.h \
   protocol.h \
   psbt.h \
   random.h \
@@ -300,6 +301,7 @@ libbitcoin_server_a_SOURCES = \
   policy/rbf.cpp \
   policy/settings.cpp \
   pow.cpp \
+  powcache.cpp \
   rest.cpp \
   rpc/blockchain.cpp \
   rpc/mining.cpp \
@@ -434,8 +436,6 @@ libbitcoin_consensus_a_SOURCES = \
   consensus/params.h \
   consensus/tx_check.cpp \
   consensus/validation.h \
-  dbwrapper.cpp \
-  dbwrapper.h \
   hash.cpp \
   hash.h \
   prevector.h \
@@ -443,8 +443,6 @@ libbitcoin_consensus_a_SOURCES = \
   primitives/block.h \
   primitives/transaction.cpp \
   primitives/transaction.h \
-  powcache.cpp \
-  powcache.h \
   pubkey.cpp \
   pubkey.h \
   script/bitcoinconsensus.cpp \
@@ -614,17 +612,11 @@ bitcoin_tx_SOURCES += bitcoin-tx-res.rc
 endif
 
 bitcoin_tx_LDADD = \
-  $(LIBBITCOIN_SERVER) \
-  $(LIBBITCOIN_WALLET) \
-  $(LIBBITCOIN_COMMON) \
   $(LIBUNIVALUE) \
+  $(LIBBITCOIN_COMMON) \
   $(LIBBITCOIN_UTIL) \
-  $(LIBBITCOIN_ZMQ) \
   $(LIBBITCOIN_CONSENSUS) \
   $(LIBBITCOIN_CRYPTO) \
-  $(LIBLEVELDB) \
-  $(LIBLEVELDB_SSE42) \
-  $(LIBMEMENV) \
   $(LIBSECP256K1)
 
 bitcoin_tx_LDADD += $(BOOST_LIBS)
@@ -668,7 +660,7 @@ endif
 
 libbitcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
 libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1)
-libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL $(BOOST_CPPFLAGS)
+libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL $(BOOST_CPPFLAGS)
 libbitcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 
 endif

--- a/src/chain.h
+++ b/src/chain.h
@@ -9,6 +9,7 @@
 #include <arith_uint256.h>
 #include <consensus/params.h>
 #include <flatfile.h>
+#include <powcache.h>
 #include <primitives/block.h>
 #include <tinyformat.h>
 #include <uint256.h>
@@ -360,7 +361,7 @@ public:
         block.nTime           = nTime;
         block.nBits           = nBits;
         block.nNonce          = nNonce;
-        return block.GetHash();
+        return powHashProxy.GetHash(block);
     }
 
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -163,6 +163,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::QT, "qt"},
     {BCLog::LEVELDB, "leveldb"},
     {BCLog::VALIDATION, "validation"},
+    {BCLog::POWCACHE, "powcache"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -55,6 +55,7 @@ namespace BCLog {
         QT          = (1 << 19),
         LEVELDB     = (1 << 20),
         VALIDATION  = (1 << 21),
+        POWCACHE    = (1 << 22),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/powcache.cpp
+++ b/src/powcache.cpp
@@ -22,7 +22,7 @@ bool CPowCacheDB::WriteCacheEntry(const uint256& lookupHash, const uint256& powH
 void CPowHashProxy::Init(size_t nCacheSize)
 {
     pow_cachedb.reset();
-    pow_cachedb.reset(new CPowCacheDB(GetDataDir(false) / "powcache", nCacheSize, false, false));
+    pow_cachedb.reset(new CPowCacheDB(GetDataDir() / "powcache", nCacheSize, false, false));
 };
 
 void CPowHashProxy::Stop()

--- a/src/powcache.cpp
+++ b/src/powcache.cpp
@@ -4,21 +4,47 @@
 
 #include <powcache.h>
 
-PowCacheDB pow_cache(GetDataDir(false) / "powcache", 4194304, false, false);
-
-PowCacheDB::PowCacheDB(fs::path ldb_path, size_t nCacheSize, bool fMemory, bool fWipe) :
+CPowCacheDB::CPowCacheDB(fs::path ldb_path, size_t nCacheSize, bool fMemory, bool fWipe) :
     db(ldb_path, nCacheSize, fMemory, fWipe, true)
 {}
 
-bool PowCacheDB::HaveCacheEntry(const uint256& lookupHash) const {
-    return db.Exists(lookupHash);
+Optional<uint256> CPowCacheDB::GetCacheEntry(const uint256& lookupHash) const {
+    uint256 blockHash;
+    if (db.Read(lookupHash, blockHash)) return blockHash;
+
+    return nullopt;
 }
 
-bool PowCacheDB::GetCacheEntry(const uint256& lookupHash, uint256& powHash) const {
-    return db.Read(lookupHash, powHash);
-}
-
-bool PowCacheDB::WriteCacheEntry(const uint256& lookupHash, uint256& powHash) {
+bool CPowCacheDB::WriteCacheEntry(const uint256& lookupHash, const uint256& powHash) {
     return db.Write(lookupHash, powHash);
 }
 
+void CPowHashProxy::Init(size_t nCacheSize)
+{
+    pow_cachedb.reset();
+    pow_cachedb.reset(new CPowCacheDB(GetDataDir(false) / "powcache", nCacheSize, false, false));
+};
+
+void CPowHashProxy::Stop()
+{
+    pow_cachedb.reset();
+};
+
+uint256 CPowHashProxy::GetHash(CBlockHeader& block)
+{
+    if(pow_cachedb)
+    {
+        uint256 cacheHash = block.GetCacheHash();
+        
+        if (Optional<uint256> optionalBlockHash = pow_cachedb->GetCacheEntry(cacheHash))
+            return optionalBlockHash.get();
+        
+        uint256 blockHash = block.GetHash();
+        pow_cachedb->WriteCacheEntry(cacheHash, blockHash);
+        return blockHash;
+    }
+
+    return block.GetHash();
+};
+
+CPowHashProxy powHashProxy;

--- a/src/powcache.cpp
+++ b/src/powcache.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 barrystyle
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <powcache.h>
+
+PowCacheDB pow_cache(GetDataDir(false) / "powcache", 4194304, false, false);
+
+PowCacheDB::PowCacheDB(fs::path ldb_path, size_t nCacheSize, bool fMemory, bool fWipe) :
+    db(ldb_path, nCacheSize, fMemory, fWipe, true)
+{}
+
+bool PowCacheDB::HaveCacheEntry(const uint256& lookupHash) const {
+    return db.Exists(lookupHash);
+}
+
+bool PowCacheDB::GetCacheEntry(const uint256& lookupHash, uint256& powHash) const {
+    return db.Read(lookupHash, powHash);
+}
+
+bool PowCacheDB::WriteCacheEntry(const uint256& lookupHash, uint256& powHash) {
+    return db.Write(lookupHash, powHash);
+}
+

--- a/src/powcache.cpp
+++ b/src/powcache.cpp
@@ -8,14 +8,14 @@ CPowCacheDB::CPowCacheDB(fs::path ldb_path, size_t nCacheSize, bool fMemory, boo
     db(ldb_path, nCacheSize, fMemory, fWipe, true)
 {}
 
-Optional<uint256> CPowCacheDB::GetCacheEntry(const uint256& lookupHash) const {
+Optional<uint256> CPowCacheDB::GetCacheEntry(const uint160& lookupHash) const {
     uint256 blockHash;
     if (db.Read(lookupHash, blockHash)) return blockHash;
 
     return nullopt;
 }
 
-bool CPowCacheDB::WriteCacheEntry(const uint256& lookupHash, const uint256& powHash) {
+bool CPowCacheDB::WriteCacheEntry(const uint160& lookupHash, const uint256& powHash) {
     return db.Write(lookupHash, powHash);
 }
 
@@ -34,7 +34,7 @@ uint256 CPowHashProxy::GetHash(CBlockHeader& block)
 {
     if(pow_cachedb)
     {
-        uint256 cacheHash = block.GetCacheHash();
+        uint160 cacheHash = block.GetCacheHash();
         
         if (Optional<uint256> optionalBlockHash = pow_cachedb->GetCacheEntry(cacheHash))
             return optionalBlockHash.get();

--- a/src/powcache.h
+++ b/src/powcache.h
@@ -6,39 +6,44 @@
 #define BITCOIN_POWCACHE_H
 
 #include <dbwrapper.h>
+#include <optional.h>
+#include <primitives/block.h>
 #include <uint256.h>
 
-/** Implements a persistent hash lookup cache, using SHA1 hash as the key
- * allowing instant retrieval of the more cpu-expensive pow hash if known.
+/** Implements a persistent hash lookup cache, using SHA1 hash as the key.
+ * If hash was previosuly encountered and stored it allows for instant retrieval of the more cpu-expensive pow HeavyHash.
  * The hash is not tied to a height, preventing invalid hashes from potentially
  * being returned in the instance of a block reorganisation etc.
  */
-class PowCacheDB
+
+//! Max memory allocated for HeavyHash cache (4 MiB ~ 4.2 MB)
+static const int64_t nMaxHeavyHashCache = 4;
+
+class CPowCacheDB
 {
 protected:
     CDBWrapper db;
 
-private:
-    int hit_log{0};
-    int miss_log{0};
-
 public:
-    explicit PowCacheDB(fs::path ldb_path, size_t nCacheSize, bool fMemory, bool fWipe);
-
-    int hit(bool inc = false) {
-        if (inc) ++hit_log;
-        return hit_log;
-    }
-    int miss(bool inc = false) {
-        if (inc) ++miss_log;
-        return miss_log;
-    }
-
-    bool HaveCacheEntry(const uint256& lookupHash) const;
-    bool GetCacheEntry(const uint256& lookupHash, uint256& powHash) const;
-    bool WriteCacheEntry(const uint256& lookupHash, uint256& powHash);
+    explicit CPowCacheDB(fs::path ldb_path, size_t nCacheSize, bool fMemory, bool fWipe);
+    
+    // Read method already checks for record existence
+    Optional<uint256> GetCacheEntry(const uint256& lookupHash) const;
+    bool WriteCacheEntry(const uint256& lookupHash, const uint256& powHash);
 };
 
-extern PowCacheDB pow_cache;
+class CPowHashProxy
+{
+protected:
+    std::unique_ptr<CPowCacheDB> pow_cachedb;
+
+public:
+    void Init(size_t nCacheSize);
+    void Stop();
+    uint256 GetHash(CBlockHeader& block);
+};
+
+// Global wrapper around CPoWCacheDB object. It is responsible for its existence, and based on this it decides how to retrieve block's hash
+extern CPowHashProxy powHashProxy;
 
 #endif // BITCOIN_POWCACHE_H

--- a/src/powcache.h
+++ b/src/powcache.h
@@ -28,8 +28,8 @@ public:
     explicit CPowCacheDB(fs::path ldb_path, size_t nCacheSize, bool fMemory, bool fWipe);
     
     // Read method already checks for record existence
-    Optional<uint256> GetCacheEntry(const uint256& lookupHash) const;
-    bool WriteCacheEntry(const uint256& lookupHash, const uint256& powHash);
+    Optional<uint256> GetCacheEntry(const uint160& lookupHash) const;
+    bool WriteCacheEntry(const uint160& lookupHash, const uint256& powHash);
 };
 
 class CPowHashProxy

--- a/src/powcache.h
+++ b/src/powcache.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 barrystyle
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POWCACHE_H
+#define BITCOIN_POWCACHE_H
+
+#include <dbwrapper.h>
+#include <uint256.h>
+
+/** Implements a persistent hash lookup cache, using SHA1 hash as the key
+ * allowing instant retrieval of the more cpu-expensive pow hash if known.
+ * The hash is not tied to a height, preventing invalid hashes from potentially
+ * being returned in the instance of a block reorganisation etc.
+ */
+class PowCacheDB
+{
+protected:
+    CDBWrapper db;
+
+private:
+    int hit_log{0};
+    int miss_log{0};
+
+public:
+    explicit PowCacheDB(fs::path ldb_path, size_t nCacheSize, bool fMemory, bool fWipe);
+
+    int hit(bool inc = false) {
+        if (inc) ++hit_log;
+        return hit_log;
+    }
+    int miss(bool inc = false) {
+        if (inc) ++miss_log;
+        return miss_log;
+    }
+
+    bool HaveCacheEntry(const uint256& lookupHash) const;
+    bool GetCacheEntry(const uint256& lookupHash, uint256& powHash) const;
+    bool WriteCacheEntry(const uint256& lookupHash, uint256& powHash);
+};
+
+extern PowCacheDB pow_cache;
+
+#endif // BITCOIN_POWCACHE_H

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -5,9 +5,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <crypto/sha1.h>
-#include <logging.h>
 #include <primitives/block.h>
-#include <powcache.h>
 #include <hash.h>
 #include <tinyformat.h>
 
@@ -16,7 +14,7 @@ uint256 CBlockHeader::GetHash() const
     return GetPoWHash();
 }
 
-uint256 CBlockHeader::GetLightHash() const
+uint256 CBlockHeader::GetCacheHash() const
 {
     uint256 hash;
     CSHA1().Write((const unsigned char*)this, 80).Finalize((unsigned char*)&hash);
@@ -24,25 +22,6 @@ uint256 CBlockHeader::GetLightHash() const
 }
 
 uint256 CBlockHeader::GetPoWHash() const
-{
-    //! light sha1 hash for lookup
-    const uint256 lookupHash = GetLightHash();
-    bool cacheEntry = pow_cache.HaveCacheEntry(lookupHash);
-    if (cacheEntry) {
-        uint256 powHash;
-        pow_cache.GetCacheEntry(lookupHash, powHash);
-        LogPrint(BCLog::POWCACHE, "%s - cachehit %6d cachemiss %6d (%s)\n", __func__, pow_cache.hit(true), pow_cache.miss(), powHash.ToString());
-        return powHash;
-    }
-
-    //! store for later usage
-    uint256 powHash = GetHeavyHash();
-    pow_cache.WriteCacheEntry(lookupHash, powHash);
-    LogPrint(BCLog::POWCACHE, "%s - cachehit %6d cachemiss %6d (%s)\n", __func__, pow_cache.hit(), pow_cache.miss(true), powHash.ToString());
-    return powHash;
-}
-
-uint256 CBlockHeader::GetHeavyHash() const
 {
     uint256 seed;
     CSHA3_256().Write(hashPrevBlock.begin(), 32).Finalize(seed.begin());

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -1,9 +1,13 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2019 The Bitcoin Core developers
+// Copyright (c) 2022 barrystyle
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <crypto/sha1.h>
+#include <logging.h>
 #include <primitives/block.h>
+#include <powcache.h>
 #include <hash.h>
 #include <tinyformat.h>
 
@@ -12,7 +16,33 @@ uint256 CBlockHeader::GetHash() const
     return GetPoWHash();
 }
 
+uint256 CBlockHeader::GetLightHash() const
+{
+    uint256 hash;
+    CSHA1().Write((const unsigned char*)this, 80).Finalize((unsigned char*)&hash);
+    return hash;
+}
+
 uint256 CBlockHeader::GetPoWHash() const
+{
+    //! light sha1 hash for lookup
+    const uint256 lookupHash = GetLightHash();
+    bool cacheEntry = pow_cache.HaveCacheEntry(lookupHash);
+    if (cacheEntry) {
+        uint256 powHash;
+        pow_cache.GetCacheEntry(lookupHash, powHash);
+        LogPrint(BCLog::POWCACHE, "%s - cachehit %6d cachemiss %6d (%s)\n", __func__, pow_cache.hit(true), pow_cache.miss(), powHash.ToString());
+        return powHash;
+    }
+
+    //! store for later usage
+    uint256 powHash = GetHeavyHash();
+    pow_cache.WriteCacheEntry(lookupHash, powHash);
+    LogPrint(BCLog::POWCACHE, "%s - cachehit %6d cachemiss %6d (%s)\n", __func__, pow_cache.hit(), pow_cache.miss(true), powHash.ToString());
+    return powHash;
+}
+
+uint256 CBlockHeader::GetHeavyHash() const
 {
     uint256 seed;
     CSHA3_256().Write(hashPrevBlock.begin(), 32).Finalize(seed.begin());

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -14,9 +14,9 @@ uint256 CBlockHeader::GetHash() const
     return GetPoWHash();
 }
 
-uint256 CBlockHeader::GetCacheHash() const
+uint160 CBlockHeader::GetCacheHash() const
 {
-    uint256 hash;
+    uint160 hash;
     CSHA1().Write((const unsigned char*)this, 80).Finalize((unsigned char*)&hash);
     return hash;
 }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -62,8 +62,7 @@ public:
 
     uint256 GetHash() const;
     uint256 GetPoWHash() const;
-    uint256 GetLightHash() const;
-    uint256 GetHeavyHash() const;
+    uint256 GetCacheHash() const;
 
     int64_t GetBlockTime() const
     {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -62,7 +62,7 @@ public:
 
     uint256 GetHash() const;
     uint256 GetPoWHash() const;
-    uint256 GetCacheHash() const;
+    uint160 GetCacheHash() const;
 
     int64_t GetBlockTime() const
     {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -62,6 +62,8 @@ public:
 
     uint256 GetHash() const;
     uint256 GetPoWHash() const;
+    uint256 GetLightHash() const;
+    uint256 GetHeavyHash() const;
 
     int64_t GetBlockTime() const
     {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1148,7 +1148,7 @@ bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::P
     }
 
     // Check the header
-    if (!CheckProofOfWork(block.GetPoWHash(), block.nBits, consensusParams))
+    if (!CheckProofOfWork(powHashProxy.GetHash(block), block.nBits, consensusParams))
         return error("ReadBlockFromDisk: Errors in block header at %s", pos.ToString());
 
     return true;
@@ -1164,7 +1164,7 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
 
     if (!ReadBlockFromDisk(block, blockPos, consensusParams))
         return false;
-    if (block.GetHash() != pindex->GetBlockHash())
+    if (powHashProxy.GetHash(block) != pindex->GetBlockHash())
         return error("ReadBlockFromDisk(CBlock&, CBlockIndex*): GetHash() doesn't match index for %s at %s",
                 pindex->ToString(), pindex->GetBlockPos().ToString());
     return true;


### PR DESCRIPTION
Implements a database that stores Heavy Hash of blocks, making node performance better compromising memory.

Yet memory should not be an issue, as entry related to one block would take up 160 bits (key) + 256 bits (value) = 416 bits.
At the current chain state of 70_000 blocks this gives only 3.64 MB.

Heavy Hash is a resource intensive hashing algorithm, and at a current state block indexation and blockchain rescaning takes up to 6-8 minutes. This strongly impedes the performance of a serving node, and makes deployment with volumes really unpleasant. This issue also causes using wallets a very worrying experience.

A simple lookup table however solves both the problems.

Links:
[Discord announcement](https://discord.com/channels/822433063237713961/822433063685718059/996763292884271226)

**Note:**
Data base is a bitcoin leveldb database, that works in the same way as `block/index` or `chainstate`.